### PR TITLE
Fix JS error when selecting card and Ideal is not available.

### DIFF
--- a/app/design/frontend/base/default/template/adyen/form/hpp.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/hpp.phtml
@@ -139,10 +139,15 @@
                                     // set the adyen_hpp payment method
                                     $('p_method_adyen_hpp').checked = true;
                                     payment.switchMethod("adyen_hpp");
-                                    if (method.value == 'ideal') {
-                                        $('payment_form_ideal').show();
-                                    } else {
-                                        $('payment_form_ideal').hide();
+
+                                    var paymentFormIdeal =  $('payment_form_ideal');
+
+                                    if(paymentFormIdeal != undefined) {
+                                        if (method.value == 'ideal') {
+                                            paymentFormIdeal.show();
+                                        } else {
+                                            paymentFormIdeal.hide();
+                                        }
                                     }
                                 };
                                 Event.observe($('hpp_type_<?php echo $_typeCode?>'), 'change', IdealChecked);


### PR DESCRIPTION
When you are using Adyen HPP as payment method and Ideal is not available as card, there will be a JS error thrown when switching between cards.