### PR TITLE
Removed requirement for magento-hackathon/magento-composer-installer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,6 @@
             "email": "support@adyen.com"
         }
     ],
-    "require": {
-        "magento-hackathon/magento-composer-installer": "2.*"
-    },
     "replace": {
         "connect20/madia_adyen": "1.*"
     }


### PR DESCRIPTION
I've removed the "magento-hackathon/magento-composer-installer" requirement from the composer.json.
Adyen does not actually relies on this module.

This requirement causes issue's if you use something else then the hackathon method or (in my case) use a newer version (dev-master) of the hackathon module.