### PR TITLE
Obscure PCI sensitive data in logs

### DIFF
--- a/app/code/community/Adyen/Payment/Helper/Pci.php
+++ b/app/code/community/Adyen/Payment/Helper/Pci.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Class Adyen_Payment_Helper_Pci
+ * @see https://www.pcisecuritystandards.org/documents/pci_ssc_quick_guide.pdf
+ */
+class Adyen_Payment_Helper_Pci
+{
+    /** @var array  */
+    protected static $_sensitiveDataKeys = ['holdername', 'expiryyear', 'expirymonth', 'issuenumber', 'cvc', 'number'];
+
+    /** @var array  */
+    protected static $_sensitiveElementPatterns;
+
+    /**
+     * Set patterns for matching sensitive strings
+     */
+    public function __construct()
+    {
+        if (isset(self::$_sensitiveElementPatterns)) {
+            return;
+        }
+
+        foreach (self::$_sensitiveDataKeys as $key) {
+            self::$_sensitiveElementPatterns[] = '/(<ns1:' . $key . '>)(.*?)(<\/ns1:' . $key . '>)/i';
+        }
+    }
+
+    /**
+     * Recursively work through an array object obscuring the values of sensitive keys
+     * Obscure any substrings matched as sensitive XML elements
+     * @param mixed $object
+     * @return mixed Original type of object
+     */
+    public function obscureSensitiveData($object)
+    {
+        if (is_array($object)) {
+            return $this->_obscureSensitiveArray($object);
+        }
+
+        if ($object instanceof ArrayAccess) {
+            return $this->_obscureSensitiveObject($object);
+        }
+
+        if (is_string($object) || is_numeric($object)) {
+            return $this->_obscureSensitiveElements($object);
+        }
+
+        return $object;
+    }
+
+    /**
+     * @param array $array
+     * @return array
+     */
+    protected function _obscureSensitiveArray(array $array)
+    {
+        foreach ($array as $key => $value) {
+            $array[$key] = $this->_obscureSensitiveKeyValue($key, $value);
+        }
+        return $array;
+    }
+
+    /**
+     * @param ArrayAccess $object E.g. Varien_Object
+     * @return ArrayAccess
+     */
+    protected function _obscureSensitiveObject(ArrayAccess $object)
+    {
+        foreach ($object as $key => $value) {
+            $object[$key] = $this->_obscureSensitiveKeyValue($key, $value);
+        }
+        return $object;
+    }
+
+    /**
+     * Replace any matched sensitive strings with an obscured version
+     * @param string $string
+     * @return string
+     */
+    protected function _obscureSensitiveElements($string)
+    {
+        return preg_replace_callback(self::$_sensitiveElementPatterns, function($matches) {
+            return $matches[1] . $this->_obscureString($matches[2]) . $matches[3];
+        }, $string);
+    }
+
+    /**
+     * Replace all but first and last characters with *
+     * @param $string
+     * @return string
+     */
+    protected function _obscureString($string)
+    {
+        $len = strlen($string);
+        if ($len > 3) {
+            return substr($string, 0, 1) . str_repeat('*', $len - 2) . substr($string, -1);
+        }
+        return str_repeat('*', $len);
+    }
+
+    /**
+     * Return value, obscured if sensitive based on key and value
+     * @param $key
+     * @param $value
+     * @return mixed
+     */
+    protected function _obscureSensitiveKeyValue($key, $value)
+    {
+        // Is this a sensitive key with a string or numeric value?
+        if (in_array(strtolower($key), self::$_sensitiveDataKeys) && (is_string($value) || is_numeric($value))) {
+            $strVal = (string) $value;
+            return $this->_obscureString($strVal);
+        }
+
+        // Recursively work through the value
+        return $this->obscureSensitiveData($value);
+    }
+}

--- a/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
@@ -44,6 +44,9 @@ abstract class Adyen_Payment_Model_Adyen_Abstract extends Mage_Payment_Model_Met
     protected $_canUseForMultishipping = false;
     protected $_canRefundInvoicePartial = true;
 
+    /** @var Adyen_Payment_Helper_Pci */
+    protected $_pciHelper;
+
     /**
      * TODO: whether a captured transaction may be voided by this gateway
      * This may happen when amount is captured, but not settled
@@ -264,9 +267,9 @@ abstract class Adyen_Payment_Model_Adyen_Abstract extends Mage_Payment_Model_Met
         //debug || log
         Mage::getResourceModel('adyen/adyen_debug')->assignData($response);
         $this->_debugAdyen();
-        Mage::log($requestData, self::DEBUG_LEVEL, "$request.log", true);
+        Mage::log($this->_pci()->obscureSensitiveData($requestData), self::DEBUG_LEVEL, "$request.log", true);
         Mage::log("Response from Adyen:", self::DEBUG_LEVEL, "$request.log", true);
-        Mage::log($response, self::DEBUG_LEVEL, "$request.log", true);
+        Mage::log($this->_pci()->obscureSensitiveData($response), self::DEBUG_LEVEL, "$request.log", true);
 
         //return $this;
         return $response;
@@ -449,13 +452,24 @@ abstract class Adyen_Payment_Model_Adyen_Abstract extends Mage_Payment_Model_Met
      */
     protected function _debugAdyen() {
         $this->writeLog("Request Headers: ");
-        $this->writeLog($this->_service->__getLastRequestHeaders());
+        $this->writeLog($this->_pci()->obscureSensitiveData($this->_service->__getLastRequestHeaders()));
         $this->writeLog("Request:");
-        $this->writeLog($this->_service->__getLastRequest());
+        $this->writeLog($this->_pci()->obscureSensitiveData(($this->_service->__getLastRequest()));
         $this->writeLog("Response Headers");
-        $this->writeLog($this->_service->__getLastResponseHeaders());
+        $this->writeLog($this->_pci()->obscureSensitiveData(($this->_service->__getLastResponseHeaders()));
         $this->writeLog("Response");
-        $this->writeLog($this->_service->__getLastResponse());
+        $this->writeLog($this->_pci()->obscureSensitiveData(($this->_service->__getLastResponse()));
+    }
+
+    /**
+     * @return Adyen_Payment_Helper_Pci
+     */
+    protected function _pci()
+    {
+        if (!isset($this->_pciHelper)) {
+            $this->_pciHelper = Mage::helper('adyen/pci');
+        }
+        return $this->_pciHelper;
     }
 
     /**
@@ -524,7 +538,7 @@ abstract class Adyen_Payment_Model_Adyen_Abstract extends Mage_Payment_Model_Met
      * @return type
      */
     public function writeLog($str) {
-        Mage::log($str, Zend_Log::DEBUG, "adyen_notification.log", true);
+        Mage::log($this->_pci()->obscureSensitiveData($str), Zend_Log::DEBUG, "adyen_notification.log", true);
         return false;
     }
 

--- a/app/code/community/Adyen/Payment/Model/Adyen/Data/Abstract.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Data/Abstract.php
@@ -25,7 +25,7 @@
  * @property   Adyen B.V
  * @copyright  Copyright (c) 2014 Adyen BV (http://www.adyen.com)
  */
-class Adyen_Payment_Model_Adyen_Data_Abstract {
+class Adyen_Payment_Model_Adyen_Data_Abstract implements ArrayAccess {
 
     /**
      * Zend_Log debug level
@@ -35,5 +35,70 @@ class Adyen_Payment_Model_Adyen_Data_Abstract {
 
     protected function _getCheckout() {
         return Mage::getSingleton('checkout/session');
+    }
+
+    /**
+     * Whether an offset exists
+     * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     * @param mixed $offset An offset to check for.
+     * @return boolean true on success or false on failure.
+     *
+     * The return value will be casted to boolean if non-boolean was returned.
+     */
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, get_object_vars($this));
+    }
+
+    /**
+     * Offset to retrieve
+     * @link http://php.net/manual/en/arrayaccess.offsetget.php
+     * @param mixed $offset
+     * The offset to retrieve.
+     * @return mixed Can return all value types.
+     */
+    public function offsetGet($offset)
+    {
+        if ($this->offsetExists($offset)) {
+            return get_object_vars($this)[$offset];
+        }
+
+        return null;
+    }
+
+    /**
+     * Offset to set
+     * @link http://php.net/manual/en/arrayaccess.offsetset.php
+     * @param mixed $offset
+     * The offset to assign the value to.
+     * @param mixed $value
+     * The value to set.
+     * @return void
+     */
+    public function offsetSet($offset, $value)
+    {
+        if (property_exists(get_class($this), $offset)) {
+            $property = new ReflectionProperty(get_class($this), $offset);
+            if ($property->isPublic()) {
+                $this->$offset = $value;
+            }
+            return;
+        }
+
+        $this->$offset = $value;
+    }
+
+    /**
+     * Offset to unset
+     * @link http://php.net/manual/en/arrayaccess.offsetunset.php
+     * @param mixed $offset
+     * The offset to unset.
+     * @return void
+     */
+    public function offsetUnset($offset)
+    {
+        if ($this->offsetExists($offset)) {
+            unset($this->$offset);
+        }
     }
 }


### PR DESCRIPTION
Currently PCI sensitive data (credit card details) are logged to disk.
This commit obscures PCI sensitive data before it is written to log
files.