### PR TITLE
Fixed SoapClient param error.

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
@@ -410,7 +410,7 @@ abstract class Adyen_Payment_Model_Adyen_Abstract extends Mage_Payment_Model_Met
                 'password' => $password,
                 'soap_version' => SOAP_1_1,
                 'style' => SOAP_DOCUMENT,
-                'encoding' => SOAP_LITERAL,
+                'use' => SOAP_LITERAL,
                 'location' => $location,
                 'trace' => 1,
                 'classmap' => $classmap));


### PR DESCRIPTION
When running Magento on HHVM I get the following error:
```
SOAP_ERROR: Invalid 'encoding' option - '2'
```
This is due to an error when the SOAP Client is instantiated.

The encoding option accepts a string identifier of the encoding, eg. 'UTF-8', 'ISO-8859-1'. Soap messages as always sent as UTF-8, this options is used to convert strings before sending the soap request.

To use SOAP requests with what is called literal encoding the "use" option should be set to SOAP_LITERAL.