### PR TITLE
Content-Type headers need to be cleared for use with php-fpm / nginx.

### DIFF
--- a/app/code/community/Adyen/Payment/controllers/ProcessController.php
+++ b/app/code/community/Adyen/Payment/controllers/ProcessController.php
@@ -421,6 +421,7 @@ class Adyen_Payment_ProcessController extends Mage_Core_Controller_Front_Action 
                     return;
                 } else {
                     $this->getResponse()
+	                    ->clearHeader('Content-Type')
                         ->setHeader('Content-Type', 'text/html')
                         ->setBody("[accepted]");
                     return;
@@ -462,6 +463,7 @@ class Adyen_Payment_ProcessController extends Mage_Core_Controller_Front_Action 
                     }
                 }
                 $this->getResponse()
+	                ->clearHeader('Content-Type')
                     ->setHeader('Content-Type', 'text/html')
                     ->setBody("[accepted]");
                 return;
@@ -509,6 +511,7 @@ class Adyen_Payment_ProcessController extends Mage_Core_Controller_Front_Action 
         $html = $this->processPosResponse($response);
 
         $this->getResponse()
+	        ->clearHeader('Content-Type')
             ->setHeader('Content-Type', 'text/html')
             ->setBody($html);
 


### PR DESCRIPTION
We had some issues running the adyen magento module on a Nginx server with PHP-FPM.
To fix an exception about duplicate header 'Content-Type' I added a clearHeader('Content-Type') before setting the new Content-Type. This fixes the issue.