### PR TITLE
PHP 5.3 compatibility for arrays

### DIFF
--- a/app/code/community/Adyen/Payment/Helper/Pci.php
+++ b/app/code/community/Adyen/Payment/Helper/Pci.php
@@ -7,7 +7,7 @@
 class Adyen_Payment_Helper_Pci
 {
     /** @var array  */
-    protected static $_sensitiveDataKeys = ['holdername', 'expiryyear', 'expirymonth', 'issuenumber', 'cvc', 'number'];
+    protected static $_sensitiveDataKeys = array('holdername', 'expiryyear', 'expirymonth', 'issuenumber', 'cvc', 'number');
 
     /** @var array  */
     protected static $_sensitiveElementPatterns;


### PR DESCRIPTION
PHP 5.3 compatibility for Older Magento versions which don't support php 5.4+