### PR TITLE
[TASK] Implement _isAllowed required by SUPEE-6285

### DIFF
--- a/app/code/community/Adyen/Payment/controllers/Adminhtml/Adyen/Event/QueueController.php
+++ b/app/code/community/Adyen/Payment/controllers/Adminhtml/Adyen/Event/QueueController.php
@@ -97,4 +97,12 @@ class Adyen_Payment_Adminhtml_Adyen_Event_QueueController extends Mage_Adminhtml
         $this->_redirect('*/*/');
     }
 
+    /**
+     * @return bool
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('sales/adyen_payment');
+    }
+
 }

--- a/app/code/community/Adyen/Payment/controllers/Adminhtml/ExportAdyenSettingsController.php
+++ b/app/code/community/Adyen/Payment/controllers/Adminhtml/ExportAdyenSettingsController.php
@@ -106,4 +106,12 @@ class Adyen_Payment_Adminhtml_ExportAdyenSettingsController extends Mage_Adminht
         }
     }
 
+    /**
+     * @return bool
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('system/config/payment');
+    }
+
 }

--- a/app/code/community/Adyen/Payment/controllers/Adminhtml/ValidateWebserverSettingsController.php
+++ b/app/code/community/Adyen/Payment/controllers/Adminhtml/ValidateWebserverSettingsController.php
@@ -82,4 +82,12 @@ class Adyen_Payment_Adminhtml_ValidateWebserverSettingsController extends Mage_A
         echo $result;
         return;
     }
+
+    /**
+     * @return bool
+     */
+    protected function _isAllowed()
+    {
+        return Mage::getSingleton('admin/session')->isAllowed('system/config/payment');
+    }
 }


### PR DESCRIPTION
Added missing "_isAllowed" functions. These functions are required after applying Magento's SUPEE-6285 patch for accessing Admin controllers with custom ACL.