### PR TITLE
"Allow multiple merchants" option in adyen payment method default settings

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Authenticate.php
+++ b/app/code/community/Adyen/Payment/Model/Authenticate.php
@@ -113,7 +113,9 @@ class Adyen_Payment_Model_Authenticate extends Mage_Core_Model_Abstract {
             }
         }
 
-        $accountCmp = strcmp($submitedMerchantAccount, $internalMerchantAccount);
+        $accountCmp = !$this->_getConfigData('multiple_merchants')
+            ? strcmp($submitedMerchantAccount, $internalMerchantAccount)
+            : 0;
         $usernameCmp = strcmp($_SERVER['PHP_AUTH_USER'], $username);
         $passwordCmp = strcmp($_SERVER['PHP_AUTH_PW'], $password);
         if ($accountCmp === 0 && $usernameCmp === 0 && $passwordCmp === 0) {

--- a/app/code/community/Adyen/Payment/etc/system.xml
+++ b/app/code/community/Adyen/Payment/etc/system.xml
@@ -128,12 +128,22 @@
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>
                                 </notification_password>
+                                <multiple_merchants translate="label">
+                                    <label>Allow multiple merchants</label>
+                                    <comment>Allow notifications from other merchant accounts.<br/>Notification username and password should be the same for all merchant accounts</comment>
+                                    <frontend_type>select</frontend_type>
+                                    <source_model>adminhtml/system_config_source_yesno</source_model>
+                                    <sort_order>60</sort_order>
+                                    <show_in_default>1</show_in_default>
+                                    <show_in_website>0</show_in_website>
+                                    <show_in_store>0</show_in_store>
+                                </multiple_merchants>
                                 <ws_username_test translate="label">
                                     <label>Test: Web Service User Name</label>
                                     <tooltip>Find this in your Test Adyen Customer Area => Settings => Users => System. Normally this will be ws@Company.YourCompanyAccount. Copy and Paste the exact ws user name here.</tooltip>
                                     <config_path>payment/adyen_abstract/ws_username_test</config_path>
                                     <frontend_type>text</frontend_type>
-                                    <sort_order>60</sort_order>
+                                    <sort_order>70</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>
@@ -144,7 +154,7 @@
                                     <config_path>payment/adyen_abstract/ws_password_test</config_path>
                                     <frontend_type>obscure</frontend_type>
                                     <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
-                                    <sort_order>70</sort_order>
+                                    <sort_order>80</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>
@@ -155,7 +165,7 @@
                                     <config_path>payment/adyen_abstract/ws_test_button</config_path>
                                     <modus>test</modus>
                                     <frontend_model>adyen/adminhtml_system_config_testWebserverConfiguration</frontend_model>
-                                    <sort_order>80</sort_order>
+                                    <sort_order>90</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                     <show_in_store></show_in_store>
@@ -165,7 +175,7 @@
                                     <tooltip>This is only applicable if you have a Live account. Find this in your Live Adyen Customer Area => Settings => Users => System. Normally this will be ws@Company.YourCompanyAccount. Copy and Paste the exact ws user name here.</tooltip>
                                     <config_path>payment/adyen_abstract/ws_username_live</config_path>
                                     <frontend_type>text</frontend_type>
-                                    <sort_order>90</sort_order>
+                                    <sort_order>100</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>
@@ -177,7 +187,7 @@
                                     <config_path>payment/adyen_abstract/ws_password_live</config_path>
                                     <frontend_type>obscure</frontend_type>
                                     <backend_model>adminhtml/system_config_backend_encrypted</backend_model>
-                                    <sort_order>100</sort_order>
+                                    <sort_order>110</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>
@@ -188,7 +198,7 @@
                                     <config_path>payment/adyen_abstract/ws_live_button</config_path>
                                     <modus>live</modus>
                                     <frontend_model>adyen/adminhtml_system_config_testWebserverConfiguration</frontend_model>
-                                    <sort_order>110</sort_order>
+                                    <sort_order>120</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                 </ws_live_button>
@@ -198,7 +208,7 @@
                                     <tooltip>Immediate is the default. Set to manual if you want to perform the capture of funds manually later (only affects credit cards and a few alternative payment methods). You need to change this setting as well in Adyen Customer Area => Settings => Merchant Settings => Capture Delay. If you have selected a capture delay of a couple of days in Adyen keep it here on immediate</tooltip>
                                     <source_model>adyen/source_captureModes</source_model>
                                     <config_path>payment/adyen_abstract/capture_mode</config_path>
-                                    <sort_order>120</sort_order>
+                                    <sort_order>130</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>
@@ -209,7 +219,7 @@
                                     <frontend_type>select</frontend_type>
                                     <config_path>payment/adyen_abstract/order_status</config_path>
                                     <source_model>adminhtml/system_config_source_order_status_new</source_model>
-                                    <sort_order>130</sort_order>
+                                    <sort_order>140</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>
@@ -220,7 +230,7 @@
                                     <frontend_type>select</frontend_type>
                                     <config_path>payment/adyen_abstract/payment_pre_authorized</config_path>
                                     <source_model>adminhtml/system_config_source_order_status_newprocessing</source_model>
-                                    <sort_order>140</sort_order>
+                                    <sort_order>150</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>
@@ -232,7 +242,7 @@
                                     <frontend_type>select</frontend_type>
                                     <config_path>payment/adyen_abstract/payment_authorized</config_path>
                                     <source_model>adminhtml/system_config_source_order_status_processing</source_model>
-                                    <sort_order>150</sort_order>
+                                    <sort_order>160</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>
@@ -243,7 +253,7 @@
                                     <frontend_type>select</frontend_type>
                                     <config_path>payment/adyen_abstract/payment_cancelled</config_path>
                                     <source_model>adyen/source_cancelModes</source_model>
-                                    <sort_order>160</sort_order>
+                                    <sort_order>170</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>
@@ -253,7 +263,7 @@
                                     <frontend_type>select</frontend_type>
                                     <config_path>payment/adyen_abstract/debug</config_path>
                                     <source_model>adminhtml/system_config_source_yesno</source_model>
-                                    <sort_order>170</sort_order>
+                                    <sort_order>180</sort_order>
                                     <show_in_default>1</show_in_default>
                                     <show_in_website>1</show_in_website>
                                     <show_in_store>0</show_in_store>


### PR DESCRIPTION
This option disables the check on merchant account when notifications are
received. This makes it possible to use multiple merchant accounts in one
magento environment. (one merchant account per website for instance)