### PR TITLE
PHP 5.3 compatibility for arrays

### DIFF
--- a/app/code/community/Adyen/Payment/sql/adyen_setup/mysql4-upgrade-2.3.1.1-2.3.1.2.php
+++ b/app/code/community/Adyen/Payment/sql/adyen_setup/mysql4-upgrade-2.3.1.1-2.3.1.2.php
@@ -60,11 +60,11 @@ $oAttribute->setData('sort_order', $attributeSortOrder);
 $oAttribute->save();
 
 
-$connection->addColumn($this->getTable('sales/billing_agreement'), 'agreement_data', [
+$connection->addColumn($this->getTable('sales/billing_agreement'), 'agreement_data', array(
     'type' => Varien_Db_Ddl_Table::TYPE_TEXT,
     'nullable' => true,
     'comment' => 'Agreement Data'
-]);
+));
 
 
 $installer->endSetup();


### PR DESCRIPTION
PHP 5.3 compatibility for Older Magento versions, similar to https://github.com/Adyen/magento/commit/2f3bf8aeb00b49e65627d25dff3e96d08ec6496b