### PR TITLE
B: Only add referenceId to method code when method is adyen_oneclick

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Billing/Agreement.php
+++ b/app/code/community/Adyen/Payment/Model/Billing/Agreement.php
@@ -119,8 +119,13 @@ class Adyen_Payment_Model_Billing_Agreement
     {
         if (is_null($this->_paymentMethodInstance)) {
             $methodCode = $this->getMethodCode();
-            $referenceId = $this->getReferenceId();
-            $methodInstanceName = $methodCode . "_" . $referenceId;
+            if ($this->getMethodCode() == 'adyen_oneclick') {
+                $referenceId = $this->getReferenceId();
+                $methodInstanceName = $methodCode . "_" . $referenceId;
+            }
+            else {
+                $methodInstanceName = $methodCode;
+            }
             $this->_paymentMethodInstance = Mage::helper('payment')->getMethodInstance($methodInstanceName);
         }
         if ($this->_paymentMethodInstance) {


### PR DESCRIPTION
We don't always want to add the reference ID to the method code of a billing request, for example when adding our own payment method to work with billing agreements.