### PR TITLE
Fixes #426 with wrong "success" flag validation.

### DIFF
--- a/app/code/community/Adyen/Payment/Model/ProcessNotification.php
+++ b/app/code/community/Adyen/Payment/Model/ProcessNotification.php
@@ -186,7 +186,7 @@ class Adyen_Payment_Model_ProcessNotification extends Mage_Core_Model_Abstract {
         $this->_updateAdyenAttributes($order, $params);
 
         // check if success is true of false
-        if (strcmp($this->_success, 'false') == 0 || strcmp($this->_success, '0') == 0) {
+        if (strcmp($this->_success, 'false') == 0 || strcmp($this->_success, '0') == 0 || strcmp($this->_success, '') == 0) {
             // Only cancel the order when it is in state pending, payment review or if the ORDER_CLOSED is failed (means split payment has not be successful)
             if($order->getState() === Mage_Sales_Model_Order::STATE_PENDING_PAYMENT || $order->getState() === Mage_Sales_Model_Order::STATE_PAYMENT_REVIEW || $this->_eventCode == Adyen_Payment_Model_Event::ADYEN_EVENT_ORDER_CLOSED) {
                 $this->_debugData['_updateOrder info'] = 'Going to cancel the order';


### PR DESCRIPTION
Added an extra condition to compare` $this->_success` to an empty string. It can be an empty string because in `_declareVariables` method it is set as: `$this->_success = trim($params->getData('success'));` If `$params->getData('success')` is `false` (boolean false) as in my case, then `trim(false)` will result in an empty string.

This is not an issue elsewhere in the code as we build the condition to check if success is true or 1 which always works.