### PR TITLE
Class map should be camelCase. Fixes error when using manual capture

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Adyen/Data/Classmap.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Data/Classmap.php
@@ -29,7 +29,7 @@ class Adyen_Payment_Model_Adyen_Data_Classmap extends Adyen_Payment_Model_Adyen_
 
     public $Amount;
     public $capture;
-    public $ModificationRequest;
-    public $ModificationResult;
+    public $modificationRequest;
+    public $modificationResult;
 
 }


### PR DESCRIPTION
I don't know if this breaks something else, but when using manual capture I get the error "Class Undefined" when I do capture on-line on the order.

The problem seems to be from [Model/Adyen/Abstract.php](https://github.com/Adyen/magento/blob/develop/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php#L287)
```php
            case "capture":
                $response = $this->_service->capture(array(
                    'modificationRequest' => $requestData,
                    'modificationResult' => $modificationResult));
                break;
```

where the array keys are camelCase and not found in the Classmap.

When I changed the `Classmap` properties to camelCase it worked as expected. 

I don't know if this change breaks something else though.