### PR TITLE
If an openinvoice payment failed, we need to show a different error message to the customer.

### DIFF
--- a/app/code/community/Adyen/Payment/controllers/ProcessController.php
+++ b/app/code/community/Adyen/Payment/controllers/ProcessController.php
@@ -356,6 +356,8 @@ class Adyen_Payment_ProcessController extends Mage_Core_Controller_Front_Action 
         $params = $this->getRequest()->getParams();
         if(isset($params['authResult']) && $params['authResult'] == Adyen_Payment_Model_Event::ADYEN_EVENT_CANCELLED) {
             $session->addError($this->__('You have cancelled the order. Please try again'));
+        } elseif($order->getPayment()->getMethod() == "adyen_openinvoice") {
+            $session->addError($this->__('Your openinvoice payment failed'));
         } else {
             $session->addError($this->__('Your payment failed, Please try again later'));
         }

--- a/app/locale/de_DE/Adyen_Payment.csv
+++ b/app/locale/de_DE/Adyen_Payment.csv
@@ -17,6 +17,7 @@
 "The payment is REFUSED.", "Die Bezahlung wurde zurückgewiesen."
 "You will be redirected to Adyen in a few seconds.", "In einigen Sekunden werden Sie zu Adyen weitergeleitet."
 "Your payment failed, Please try again later","Ihre Bezahlung ist fehlgeschlagen."
+"Your openinvoice payment failed","Ihre Bezahlung ist fehlgeschlagen."
 "--Please Select--","--Bitte auswählen--"
 "Account Number","Kontonummer"
 "Account holder name","Name des Kontoinhabers"

--- a/app/locale/es_ES/Adyen_Payment.csv
+++ b/app/locale/es_ES/Adyen_Payment.csv
@@ -17,6 +17,7 @@
 "The payment is REFUSED.", "El pago fue RECHAZADO."
 "You will be redirected to Adyen in a few seconds.", "Va a ser redireccionado al website de Adyen en unos segundos."
 "Your payment failed, Please try again later","Su pago falló"
+"Your openinvoice payment failed","Su pago falló"
 "--Please Select--","--Por favor seleccione--"
 "Account Number","Número de cuenta"
 "Account holder name","Nombre del titular de cuenta"

--- a/app/locale/fr_FR/Adyen_Payment.csv
+++ b/app/locale/fr_FR/Adyen_Payment.csv
@@ -17,6 +17,7 @@
 "The payment is REFUSED.", "Le paiement a été refusé."
 "You will be redirected to Adyen in a few seconds.", "Vous allez maintenant être redirigé dans quelques secondes."
 "Your payment failed, Please try again later","Votre paiement a échoué"
+"Your openinvoice payment failed","Votre paiement a échoué"
 "--Please Select--","--Merci de sélectionner--"
 "Account Number","Numéro de compte"
 "Account holder name","Nom du titulaire du compte"

--- a/app/locale/nl_NL/Adyen_Payment.csv
+++ b/app/locale/nl_NL/Adyen_Payment.csv
@@ -60,6 +60,7 @@
 "Female","Vrouw"
 "You have cancelled the order. Please try again","U heeft de betaling geannuleerd, probeer het nogmaals."
 "Your payment failed, Please try again later","Deze betaalmethode is niet beschikbaar voor u op het moment. Kies voor andere betaalmethode om de bestelling af te ronden"
+"Your openinvoice payment failed","Deze betaalmethode is momenteel niet beschikbaar voor u. Kies voor een andere betaalmethode of neem contact op met de helpdesk."
 "Bank account holder name","Naam rekeninghouder",
 "IBAN","IBAN"
 "Invalid Iban number.","Ongeldig IBAN nummer"


### PR DESCRIPTION
AfterPay has the requirement that in case of an error a text like this will be shown to the customer:

`Het spijt ons u te moeten mededelen dat uw aanvraag om uw bestelling achteraf te betalen op dit moment niet door AfterPay wordt geaccepteerd. Dit kan om diverse (tijdelijke) redenen zijn. Voor vragen over uw afwijzing kunt u contact opnemen met de Klantenservice van AfterPay. Of kijk op de website van AfterPay bij 'Veel gestelde vragen' via de link http://www.afterpay.nl/page/consument-faq onder het kopje 'Gegevenscontrole'. Wij adviseren u voor een andere betaalmethode te kiezen om alsnog de betaling van uw bestelling af te ronden.`

With this adjustment the error message for the open invoice payment method can be translated separately from the normal error message.