### PR TITLE
Add a filter index to prevent ambiguous columns

### DIFF
--- a/app/design/adminhtml/default/default/layout/adyen.xml
+++ b/app/design/adminhtml/default/default/layout/adyen.xml
@@ -35,6 +35,7 @@
                 <arguments module="ordergrid" translate="header">
                     <header>Adyen Status</header>
                     <index>adyen_event_code</index>
+                    <filter_index>main_table.adyen_event_code</filter_index>
                     <width>50px</width>
                     <type>options</type>
                     <filter>adyen/adminhtml_sales_order_filter_adyen</filter>


### PR DESCRIPTION
When sales_flat_order_payment is joined on the order grid you cannot filter on adyen_event_code anymore and this error is thrown:
Integrity constraint violation: 1052 Column 'adyen_event_code' in where clause is ambiguous

The filter_index solves this.