### PR TITLE
Bugfix: if region is not in your address the openinvoice address diff…

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Adyen/Openinvoice.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Openinvoice.php
@@ -34,6 +34,11 @@ class Adyen_Payment_Model_Adyen_Openinvoice extends Adyen_Payment_Model_Adyen_Hp
     protected $_paymentMethod = 'openinvoice';
 
 
+    /**
+     * @param Mage_Sales_Model_Quote $quote
+     * @param int|null $checksBitMask
+     * @return bool
+     */
     public function isApplicableToQuote($quote, $checksBitMask)
     {
 
@@ -51,24 +56,28 @@ class Adyen_Payment_Model_Adyen_Openinvoice extends Adyen_Payment_Model_Adyen_Hp
         if($this->_getConfigData('different_address_disable', 'adyen_openinvoice')) {
 
             // get billing and shipping information
-            $billing = $quote->getBillingAddress()->getData();
-            $shipping = $quote->getShippingAddress()->getData();
+            $billing = $quote->getBillingAddress();
+            $shipping = $quote->getShippingAddress();
 
-            // check if the following items are different: street, city, postcode, region, countryid
-            if(isset($billing['street']) && isset($billing['city']) && $billing['postcode'] && isset($billing['region']) && isset($billing['country_id'])) {
-                $billingAddress = array($billing['street'], $billing['city'], $billing['postcode'], $billing['region'],$billing['country_id']);
-            } else {
-                $billingAddress = array();
-            }
-            if(isset($shipping['street']) && isset($shipping['city']) && $shipping['postcode'] && isset($shipping['region']) && isset($shipping['country_id'])) {
-                $shippingAddress = array($shipping['street'], $shipping['city'], $shipping['postcode'], $shipping['region'],$shipping['country_id']);
-            } else {
-                $shippingAddress = array();
-            }
+            // check if the following items are different: street, city, postcode, region, countryId
+            $billingAddress = array(
+                $billing->getStreetFull(),
+                $billing->getCity(),
+                $billing->getPostcode(),
+                $billing->getRegion(),
+                $billing->getCountryId(),
+            );
+
+            $shippingAddress = array(
+                $shipping->getStreetFull(),
+                $shipping->getCity(),
+                $shipping->getPostcode(),
+                $shipping->getRegion(),
+                $shipping->getCountryId(),
+            );
 
             // if the result are not the same don't show the payment method open invoice
-            $diff = array_diff($billingAddress,$shippingAddress);
-            if(is_array($diff) && !empty($diff)) {
+            if($billingAddress !== $shippingAddress) {
                 return false;
             }
         }


### PR DESCRIPTION
…erence check will always resolve to array().

This can be fixed by using the magic methods of billing/shipping addresses and comparing arrays can be done using === and !==
http://php.net/manual/en/language.operators.array.php