### PR TITLE
reset tax if customer switches to another payment method

### DIFF
--- a/app/code/community/Adyen/Fee/Model/Sales/Quote/Address/Total/Tax/PaymentFee.php
+++ b/app/code/community/Adyen/Fee/Model/Sales/Quote/Address/Total/Tax/PaymentFee.php
@@ -37,6 +37,8 @@ class Adyen_Fee_Model_Sales_Quote_Address_Total_Tax_PaymentFee extends Mage_Sale
         }
 
         if (!$address->getPaymentFeeAmount()) {
+            $address->setPaymentFeeTax(0);
+            $address->setBasePaymentFeeTax(0);
             return $this;
         }
 


### PR DESCRIPTION
Hi,
I noticed that if I choose Cash as payment method, then I switch to another payment method, payment fee tax doesn't go away and makes the total wrong.