### PR TITLE
+: first status cancel then succes issue with ideal.

### DIFF
--- a/app/code/community/Adyen/Payment/Model/ValidateResultUrl.php
+++ b/app/code/community/Adyen/Payment/Model/ValidateResultUrl.php
@@ -134,6 +134,13 @@ class Adyen_Payment_Model_ValidateResultUrl extends Mage_Core_Model_Abstract {
         switch ($authResult) {
 
             case Adyen_Payment_Model_Event::ADYEN_EVENT_AUTHORISED:
+                // do nothing wait for the notification
+                $this->_debugData['Step4'] = 'Add AUTHORISED to adyen event code, further wait for the notification';
+
+                $order->setAdyenEventCode($authResult);
+                $order->save();
+
+                break;
             case Adyen_Payment_Model_Event::ADYEN_EVENT_PENDING:
                 // do nothing wait for the notification
                 $this->_debugData['Step4'] = 'Do nothing wait for the notification';


### PR DESCRIPTION
First we get the message that the order payment where canceled, thats when we cancel the order.
Then we get the message that the order payment is succesful, then it tries to proccess the order.
Causing the order to come in a state, not able to do anything anymore with the order.