### PR TITLE
Date-of-birth widget in openinvoice 

### DIFF
--- a/app/design/frontend/base/default/template/adyen/form/openinvoice.phtml
+++ b/app/design/frontend/base/default/template/adyen/form/openinvoice.phtml
@@ -50,7 +50,7 @@ $_code = $this->getMethodCode();
 
         <?php if($this->dobShow()):?>
         <li class="fields">
-            <?php $_dob = $this->getLayout()->createBlock('customer/widget_dob') ?>
+            <?php $_dob = $this->getLayout()->createBlock('customer/widget_dob')->setTemplate('adyen/widget/dob.phtml') ?>
 
             <?php echo $_dob->setDate($this->getDate())->setFieldIdFormat($_code.':%s')->setFieldNameFormat('payment[%s]')->toHtml() ?>
         </li>

--- a/app/design/frontend/base/default/template/adyen/widget/dob.phtml
+++ b/app/design/frontend/base/default/template/adyen/widget/dob.phtml
@@ -1,0 +1,41 @@
+<?php
+/**
+ * @see Mage_Customer_Block_Widget_Dob
+ */
+?>
+<label for="<?php echo $this->getFieldId('month')?>"<?php if ($this->isRequired()) echo ' class="required"' ?>><?php if ($this->isRequired()) echo '<em>*</em>' ?><?php echo $this->__('Date of Birth') ?></label>
+<div class="input-box customer-dob customer-dob-adyen-openinvoice">
+    <?php
+    $this->setDateInput('d',
+        '<div class="dob-day">
+             <input type="text" id="' . $this->getFieldId('day') . '" name="' . $this->getFieldName('day') . '" value="' . $this->getDay() . '" title="' . $this->__('Day') . '" class="input-text required-entry validate-custom" ' . $this->getFieldParams() . ' />
+             <label for="' . $this->getFieldId('day') . '">' . $this->__('DD') . '</label>
+         </div>'
+    );
+
+    $this->setDateInput('m',
+        '<div class="dob-month">
+             <input type="text" id="' . $this->getFieldId('month') . '" name="' . $this->getFieldName('month') . '" value="' . $this->getMonth()  . '" title="' . $this->__('Month')  . '" class="input-text required-entry validate-custom" ' . $this->getFieldParams()  . ' />
+             <label for="' . $this->getFieldId('month') . '">' . $this->__('MM')  . '</label>
+         </div>'
+    );
+
+    $this->setDateInput('y',
+        '<div class="dob-year">
+             <input type="text" id="' . $this->getFieldId('year') . '" name="' . $this->getFieldName('year') . '" value="' . $this->getYear()  . '" title="' . $this->__('Year')  . '" class="input-text required-entry validate-custom" ' . $this->getFieldParams()  . ' />
+             <label for="' . $this->getFieldId('year') . '">' . $this->__('YYYY')  . '</label>
+         </div>'
+    );
+    ?>
+    <?php echo $this->getSortedDateInputs() ?>
+    <div class="dob-full" style="display:none;">
+        <input type="hidden" id="<?php echo $this->getFieldId('dob')?>" name="<?php echo $this->getFieldName('dob')?>" />
+    </div>
+
+    <div class="validation-advice" style="display:none;"></div>
+</div>
+<script type="text/javascript">
+    //<![CDATA[
+    var customer_dob = new Varien.DOB('.customer-dob-adyen-openinvoice', <?php echo $this->isRequired() ? 'true' : 'false' ?>, '<?php echo $this->getDateFormat() ?>');
+    //]]>
+</script>


### PR DESCRIPTION
We had a problem after adding date-of-birth in customer checkout, the validation of the date-of-birth widget in openinvoice failed. Adding a special Adyen template for date-of-birth widget used in openinvoice with another validation class. 

Martijn van der Hulst will contact you over this.