### PR TITLE
Trim whitespace and strip newlines from product name

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Adyen/Openinvoice.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Openinvoice.php
@@ -336,7 +336,7 @@ class Adyen_Payment_Model_Adyen_Openinvoice extends Adyen_Payment_Model_Adyen_Hp
             ++$count;
             $linename = "line".$count;
             $additional_data_sign['openinvoicedata.' . $linename . '.currencyCode'] = $currency;
-            $additional_data_sign['openinvoicedata.' . $linename . '.description'] = $item->getName();
+            $additional_data_sign['openinvoicedata.' . $linename . '.description'] = str_replace("\n", '', trim($item->getName()));
             $additional_data_sign['openinvoicedata.' . $linename . '.itemAmount'] = $helper->formatAmount($item->getPrice(), $currency);
             $additional_data_sign['openinvoicedata.' . $linename . '.itemVatAmount'] = ($item->getTaxAmount() > 0 && $item->getPriceInclTax() > 0) ? $helper->formatAmount($item->getPriceInclTax(), $currency) - $helper->formatAmount($item->getPrice(), $currency):$helper->formatAmount($item->getTaxAmount(), $currency);
 


### PR DESCRIPTION
Generated Hmac key was invalid when a newline existed in a product name.
(just trim wasn't enough since the problem also occured when a newline was in
the middle of the product name)