### PR TITLE
Fixed problem with capture and creditmemo when using different currencies.

### DIFF
--- a/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Abstract.php
@@ -118,6 +118,12 @@ abstract class Adyen_Payment_Model_Adyen_Abstract extends Mage_Payment_Model_Met
 
         // if amount is a full refund send a refund/cancelled request so if it is not captured yet it will cancel the order
         $grandTotal = $order->getGrandTotal();
+        $currency   = $order->getOrderCurrencyCode();
+
+        if ($payment->hasCreditmemo() && $currency != $order->getBaseCurrencyCode()) {
+                $creditmemo = $payment->getCreditmemo();
+                $amount     = $creditmemo->getGrandTotal();
+        }
 
         if($grandTotal == $amount) {
             $order->getPayment()->getMethodInstance()->SendCancelOrRefund($payment, $pspReference);
@@ -203,6 +209,13 @@ abstract class Adyen_Payment_Model_Adyen_Abstract extends Mage_Payment_Model_Met
         $payment->setStatus(self::STATUS_APPROVED)
             ->setTransactionId($this->getTransactionId())
             ->setIsTransactionClosed(0);
+        $order      = $payment->getOrder();
+        $currency   = $order->getOrderCurrencyCode();
+
+        if ($payment->hasCurrentInvoice() && $currency != $order->getBaseCurrencyCode()) {
+                $invoice = $payment->getCurrentInvoice();
+                $amount  = $invoice->getGrandTotal();
+        }
 
         // do capture request to adyen
         $order = $payment->getOrder();

--- a/app/code/community/Adyen/Payment/Model/Adyen/Data/ModificationRequest.php
+++ b/app/code/community/Adyen/Payment/Model/Adyen/Data/ModificationRequest.php
@@ -37,7 +37,7 @@ class Adyen_Payment_Model_Adyen_Data_ModificationRequest extends Adyen_Payment_M
     public function create(Varien_Object $payment, $amount, $merchantAccount, $pspReference = null)
     {
         $order = $payment->getOrder();
-        $currency = $order->getBaseCurrencyCode();
+        $currency = $order->getOrderCurrencyCode();
         $incrementId = $order->getIncrementId();
 
         $this->anyType2anyTypeMap = null;

--- a/app/code/community/Adyen/Payment/Model/Observer.php
+++ b/app/code/community/Adyen/Payment/Model/Observer.php
@@ -540,4 +540,17 @@ class Adyen_Payment_Model_Observer {
 
         return $this;
     }
+    /**
+     * Set current invoice to payment when capturing.
+     *
+     * @param Varien_Event_Observer $observer
+     */
+    public function addCurrentInvoiceToPayment(Varien_Event_Observer $observer)
+    {
+        $invoice = $observer->getInvoice();
+        $payment = $observer->getPayment();
+        $payment->setCurrentInvoice($invoice);
+
+        return $this;
+    }
 }

--- a/app/code/community/Adyen/Payment/etc/config.xml
+++ b/app/code/community/Adyen/Payment/etc/config.xml
@@ -111,6 +111,14 @@
             </groups>
         </payment>
         <events>
+            <sales_order_payment_capture>
+                <observers>
+                    <adyen_payment_capture>
+                        <class>adyen/observer</class>
+                        <method>addCurrentInvoiceToPayment</method>
+                    </adyen_payment_capture>
+                </observers>
+            </sales_order_payment_capture>
             <controller_action_predispatch>
                 <observers>
                     <adyen_payment_hpp>


### PR DESCRIPTION
Fixes issue #457.
Get the same currency as the order was made in when doing a capture / refund i.e use getGrandTotal of the invoice/creditmemo instead using getBaseGrandTotal.
